### PR TITLE
Fix restoration to use correct environment instead of defaulting to primary

### DIFF
--- a/controllers/restorationHandler.ts
+++ b/controllers/restorationHandler.ts
@@ -21,7 +21,7 @@ export default async function restorationHandler(
 
   const client = buildClient({
     apiToken: process.env.DATOCMS_FULLACCESS_API_TOKEN as string,
-    environment: requestBody.environment,
+    environment: recordBody.environment,
   });
 
   let restoredRecord;


### PR DESCRIPTION
This fix ensures records are restored in the correct environment instead of defaulting to the primary environment.

Previously, restoration always targeted the primary environment, which caused issues when locales or schema differed.

This change ensures environment context is preserved correctly.